### PR TITLE
Fixed the URL forming error being thrown

### DIFF
--- a/src/commands/post/index.ts
+++ b/src/commands/post/index.ts
@@ -126,7 +126,7 @@ const sendAlert = (
   try {
     targetChannel.send(
       createEmbed({
-        url: generateURL(guild.id, channel.id, msgID),
+        url: 'https://discord.gg/',
         description:
           'A user tried creating a job post whilst providing invalid compensation.',
         title: 'Alert!',


### PR DESCRIPTION
An error was being thrown that the URL formed at the createJobPost method was not valid.
This commit fixes the issue and also generates a URL which leads the user to the actual posting

Error stacktrace:
```
(node:3672) UnhandledPromiseRejectionWarning: DiscordAPIError: Invalid Form Body
embed.url: Not a well formed URL.
    at RequestHandler.execute (/home/denis/code/webdev-support-bot/node_modules/discord.js/src/rest/RequestHandler.js:170:25)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
```