### PR TITLE
Hotfix: Display proper limiter time in greeter message

### DIFF
--- a/src/commands/post/env.ts
+++ b/src/commands/post/env.ts
@@ -1,19 +1,25 @@
+const {
+  MOD_CHANNEL,
+  JOB_POSTINGS_CHANNEL,
+  MINIMAL_COMPENSATION,
+  POST_LIMITER_IN_HOURS,
+} = process.env;
+
 // seconds to ms
 const AWAIT_MESSAGE_TIMEOUT =
   parseInt(process.env.AWAIT_MESSAGE_TIMEOUT) * 1000;
 
 // convert hours into seconds (H*60*60)
-const POST_LIMITER_IN_HOURS =
+const POST_LIMITER =
   process.env.NODE_ENV === 'production'
-    ? parseFloat(process.env.POST_LIMITER_IN_HOURS) * 3600
+    ? parseFloat(POST_LIMITER_IN_HOURS) * 3600
     : 0.01 * 3600; // Shorten limiter to 30 seconds for development purposes
-
-const { MOD_CHANNEL, JOB_POSTINGS_CHANNEL, MINIMAL_COMPENSATION } = process.env;
 
 export {
   MOD_CHANNEL,
   JOB_POSTINGS_CHANNEL,
   MINIMAL_COMPENSATION,
+  POST_LIMITER,
   POST_LIMITER_IN_HOURS,
   AWAIT_MESSAGE_TIMEOUT,
 };

--- a/src/commands/post/index.ts
+++ b/src/commands/post/index.ts
@@ -15,6 +15,7 @@ import {
   AWAIT_MESSAGE_TIMEOUT,
   MOD_CHANNEL,
   JOB_POSTINGS_CHANNEL,
+  POST_LIMITER,
   POST_LIMITER_IN_HOURS,
   MINIMAL_COMPENSATION,
 } from './env';
@@ -348,7 +349,7 @@ const handleJobPostingRequest = async (msg: Message) => {
     }
 
     // Store the post attempt in the cache
-    cache.set(entry.key, entry.value, POST_LIMITER_IN_HOURS);
+    cache.set(entry.key, entry.value, POST_LIMITER);
 
     const answers = await formAndValidateAnswers(channel, filter, guild, send, {
       username,


### PR DESCRIPTION
Currently the message is not displaying the limiter time in hours.
The pushed code solves the issue.